### PR TITLE
[CBP-42405] chore: Update latest image version in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
   steps:
     - id: invoke-github-job
       name: invoke-github-job
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/github-actions:main-8329493223ee8cfdb1f0e56d638927a7f3faeadb
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/github-actions:main-50d6b5de1800dd213e748d18b76cdefb140f0796
       shell: sh
       env:
         RUN_ID: ${{ cloudbees.run_id }}


### PR DESCRIPTION
Update docker image tag to latest version from `action_artifacts.json`.